### PR TITLE
Ignora arquivos que não sejam markdown

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9623,8 +9623,7 @@ async function validate(){
 function getFiles() {
 	return process.env.INPUT_FILES
 		.split(' ')
-		.filter(file => !file.includes('.yml'))
-		.filter(file => !file.includes('.xml'))
+		.filter(isMarkdown)
 		.filter(file => !invalidFiles.includes(file))
 		.filter(isNumericPath)
 }
@@ -9716,6 +9715,10 @@ function isNumericPath(path) {
 	const filename = path.split('/').pop()
 	const name = filename.split('.')[0]
 	return !isNaN(name)
+}
+
+function isMarkdown(path){
+	return path.includes('.md')
 }
 
 module.exports = validate

--- a/src/test/integration.test.js
+++ b/src/test/integration.test.js
@@ -86,4 +86,12 @@ describe('Test quiz validator', () =>{
 		const result = await validate()
 		expect(result).toEqual(false)
 	})
+
+	test('must return false when no files is markdown', async () => {
+		const files = ['test.js', 'test.yml', 'test.html', 'test.md', 'metadados.md', '.cspell.json']
+		process.env.INPUT_FILES = files.concat(' ')
+
+		const result = await validate()
+		expect(result).toEqual(false)
+	})
 })

--- a/src/validate.js
+++ b/src/validate.js
@@ -61,8 +61,7 @@ async function validate(){
 function getFiles() {
 	return process.env.INPUT_FILES
 		.split(' ')
-		.filter(file => !file.includes('.yml'))
-		.filter(file => !file.includes('.xml'))
+		.filter(isMarkdown)
 		.filter(file => !invalidFiles.includes(file))
 		.filter(isNumericPath)
 }
@@ -154,6 +153,10 @@ function isNumericPath(path) {
 	const filename = path.split('/').pop()
 	const name = filename.split('.')[0]
 	return !isNaN(name)
+}
+
+function isMarkdown(path){
+	return path.includes('.md')
 }
 
 module.exports = validate


### PR DESCRIPTION
Ignora arquivos que não sejam markdown na hora de validar os quizzes, evitando analises desnecessárias. 